### PR TITLE
Normalized CodeBlock return property

### DIFF
--- a/src/main/java/me/qmx/jitescript/CodeBlock.java
+++ b/src/main/java/me/qmx/jitescript/CodeBlock.java
@@ -235,21 +235,25 @@ public class CodeBlock implements Opcodes {
     }
 
     public CodeBlock ireturn() {
+        this.returns = true;
         this.instructionList.add(new InsnNode(IRETURN));
         return this;
     }
 
     public CodeBlock freturn() {
+        this.returns = true;
         this.instructionList.add(new InsnNode(FRETURN));
         return this;
     }
 
     public CodeBlock lreturn() {
+        this.returns = true;
         this.instructionList.add(new InsnNode(LRETURN));
         return this;
     }
 
     public CodeBlock dreturn() {
+        this.returns = true;
         this.instructionList.add(new InsnNode(DRETURN));
         return this;
     }


### PR DESCRIPTION
The CodeBlock's return property was only set for reference types but not for primitives. This is rather not very consistent and is confusing for people relying on the property to be set.

There might be some greater meaning to this descision but to me it seemed as if this property was simply forgoten for the primitive return opcodes. At least, this surprised me, so I guess it might surprise others, as well.
