### PR TITLE
Adding LambdaBlock DSL for Java 8 lambdas

### DIFF
--- a/src/main/java/me/qmx/jitescript/CodeBlock.java
+++ b/src/main/java/me/qmx/jitescript/CodeBlock.java
@@ -1125,6 +1125,11 @@ public class CodeBlock implements Opcodes {
         return this;
     }
 
+    public CodeBlock lambda(JiteClass jiteClass, LambdaBlock lambda) {
+        lambda.apply(jiteClass, this);
+        return this;
+    }
+
     public VisibleAnnotation annotation(Class<?> type) {
         VisibleAnnotation annotation = new VisibleAnnotation(ci(type));
         addAnnotation(annotation);

--- a/src/main/java/me/qmx/jitescript/JiteClass.java
+++ b/src/main/java/me/qmx/jitescript/JiteClass.java
@@ -45,6 +45,7 @@ public class JiteClass implements Opcodes {
     private String sourceDebug;
     private int access = ACC_PUBLIC;
     private String parentClassName;
+    private int nextId;
 
     /**
      * Creates a new class representation
@@ -90,6 +91,10 @@ public class JiteClass implements Opcodes {
 
     public String getParentClassName() {
         return parentClassName;
+    }
+
+    public String reserveLambda() {
+        return "lambda$" + nextId++;
     }
 
     public void setAccess(int access) {

--- a/src/main/java/me/qmx/jitescript/LambdaBlock.java
+++ b/src/main/java/me/qmx/jitescript/LambdaBlock.java
@@ -1,0 +1,142 @@
+package me.qmx.jitescript;
+
+import static java.util.Arrays.asList;
+import static me.qmx.jitescript.util.CodegenUtils.ci;
+import static org.objectweb.asm.Opcodes.ACC_STATIC;
+import static org.objectweb.asm.Opcodes.ACC_SYNTHETIC;
+import static org.objectweb.asm.Opcodes.H_INVOKESTATIC;
+import static org.objectweb.asm.Opcodes.H_INVOKEVIRTUAL;
+import static org.objectweb.asm.Type.getMethodType;
+
+import java.util.ArrayList;
+import java.util.List;
+import org.objectweb.asm.Handle;
+
+public class LambdaBlock {
+
+    public static final Handle METAFACTORY = new Handle(
+        H_INVOKESTATIC,
+        "java/lang/invoke/LambdaMetafactory",
+        "metafactory",
+        "(Ljava/lang/invoke/MethodHandles$Lookup;"
+            + "Ljava/lang/String;"
+            + "Ljava/lang/invoke/MethodType;"
+            + "Ljava/lang/invoke/MethodType;"
+            + "Ljava/lang/invoke/MethodHandle;"
+            + "Ljava/lang/invoke/MethodType;"
+            + ")Ljava/lang/invoke/CallSite;"
+    );
+
+    /** The argument types to capture off the stack. */
+    private List<String> captureArguments;
+    /** Access level of the implementation method. */
+    private int implementationAccess;
+    /** Signature of the implementation method. */
+    private String implementationSignature;
+    /** Code for the implementation method. */
+    private CodeBlock implementationCode;
+    /** The functional interface type. */
+    private String interfaceType;
+    /** The functional interface method name. */
+    private String interfaceMethod;
+    /** The functional interface signature. */
+    private String interfaceSignature;
+    /** The specialized functional interface method signature. */
+    private String specializedSignature;
+
+    /**
+     * Applies this lambda block to the given class and code block, inserting the associated invokedynamic instruction.
+     *
+     * @param jiteClass The JiteClass to define the lambda within.
+     * @param block The code block referencing the lambda.
+     */
+    public void apply(JiteClass jiteClass, CodeBlock block) {
+        int handleType = ((implementationAccess & ACC_STATIC) == ACC_STATIC) ? H_INVOKESTATIC : H_INVOKEVIRTUAL;
+        String lambdaName = jiteClass.reserveLambda();
+        jiteClass.defineMethod(lambdaName, implementationAccess, implementationSignature, implementationCode);
+        block.invokedynamic(interfaceMethod, getCallSiteSignature(), METAFACTORY,
+            getMethodType(interfaceSignature),
+            new Handle(handleType, jiteClass.getClassName(), lambdaName, implementationSignature),
+            getMethodType(specializedSignature == null ? interfaceSignature : specializedSignature)
+        );
+    }
+
+    /**
+     * Specifies the argument types to capture off the stack.
+     *
+     * @param captureArguments The argument types.
+     * @return The lambda block.
+     */
+    public LambdaBlock capture(Class<?>... captureArguments) {
+        this.captureArguments = new ArrayList<String>();
+        for (Class<?> argType : captureArguments) {
+            this.captureArguments.add(ci(argType));
+        }
+        return this;
+    }
+
+    /**
+     * Specifies the argument types to capture off the stack.
+     *
+     * @param captureArguments The array of argument types.
+     * @return The lambda block.
+     */
+    public LambdaBlock capture(String... captureArguments) {
+        this.captureArguments = new ArrayList<String>(asList(captureArguments));
+        return this;
+    }
+
+    /**
+     * Defines the method to delegate the lambda to.
+     *
+     * @param implementationAccess The access level of the method.
+     * @param implementationSignature The signature of the method.
+     * @param implementationCode The code block for the method.
+     * @return The lambda block.
+     */
+    public LambdaBlock delegateTo(int implementationAccess, String implementationSignature, CodeBlock implementationCode) {
+        this.implementationSignature = implementationSignature;
+        this.implementationAccess = implementationAccess | ACC_SYNTHETIC;
+        this.implementationCode = implementationCode;
+        return this;
+    }
+
+    /**
+     * Declares the functional interface type, method name, and method signature for the lambda.
+     *
+     * @param interfaceType The interface type.
+     * @param interfaceMethod The method to implement.
+     * @param interfaceSignature The signature of the method.
+     * @return The lambda block.
+     */
+    public LambdaBlock function(String interfaceType, String interfaceMethod, String interfaceSignature) {
+        this.interfaceType = interfaceType;
+        this.interfaceMethod = interfaceMethod;
+        this.interfaceSignature = interfaceSignature;
+        return this;
+    }
+
+    /**
+     * Specializes the interface method type.
+     *
+     * @param specializedSignature The specialized method signature.
+     * @return The lambda block.
+     */
+    public LambdaBlock specialize(String specializedSignature) {
+        this.specializedSignature = specializedSignature;
+        return this;
+    }
+
+    /**
+     * Generates the call site signature.
+     *
+     * @return signature
+     */
+    private String getCallSiteSignature() {
+        StringBuilder builder = new StringBuilder();
+        for (String arg : captureArguments) {
+            builder.append(arg);
+        }
+        return "(" + builder.toString() + ")L" + interfaceType + ";";
+    }
+}

--- a/src/test/java/me/qmx/jitescript/JiteClassTest.java
+++ b/src/test/java/me/qmx/jitescript/JiteClassTest.java
@@ -28,6 +28,7 @@ import java.io.PrintStream;
 import java.lang.reflect.Field;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.util.function.UnaryOperator;
 import org.junit.Assert;
 import org.junit.Test;
 
@@ -38,7 +39,11 @@ public class JiteClassTest {
 
     public static class DynamicClassLoader extends ClassLoader {
         public Class<?> define(JiteClass jiteClass) {
-            byte[] classBytes = jiteClass.toBytes();
+            return define(jiteClass, JDKVersion.V1_6);
+        }
+
+        public Class<?> define(JiteClass jiteClass, JDKVersion version) {
+            byte[] classBytes = jiteClass.toBytes(version);
             return super.defineClass(c(jiteClass.getClassName()), classBytes, 0, classBytes.length);
         }
     }
@@ -181,5 +186,63 @@ public class JiteClassTest {
             Class<?> childClazz = classLoader.define(child);
             assertFalse(childClazz.getConstructor(new Class[0]).isAccessible());
         }
+    }
+
+    @SuppressWarnings("unchecked")
+    @Test
+    public void testLambda() throws Exception {
+
+        if (!System.getProperty("java.version").startsWith("1.8")) {
+            System.out.println("Can't run test without Java 8");
+            return;
+        }
+
+        JiteClass test = new JiteClass("Test", new String[0]) {{
+            final JiteClass jiteClass = this;
+            defineDefaultConstructor();
+            defineMethod("getCallback", ACC_PUBLIC | ACC_STATIC, sig(UnaryOperator.class), new CodeBlock() {{
+                ldc("Hello, ");
+                lambda(jiteClass, new LambdaBlock() {{
+                    function(p(UnaryOperator.class), "apply", sig(Object.class, Object.class));
+                    specialize(sig(String.class, String.class));
+                    capture(String.class);
+                    delegateTo(ACC_STATIC, sig(String.class, String.class, String.class), new CodeBlock() {{
+                        newobj(p(StringBuilder.class));
+                        dup();
+                        invokespecial(p(StringBuilder.class), "<init>", sig(void.class));
+                        aload(0);
+                        invokevirtual(p(StringBuilder.class), "append", sig(StringBuilder.class, String.class));
+                        aload(1);
+                        invokevirtual(p(StringBuilder.class), "append", sig(StringBuilder.class, String.class));
+                        ldc("!");
+                        invokevirtual(p(StringBuilder.class), "append", sig(StringBuilder.class, String.class));
+                        invokevirtual(p(StringBuilder.class), "toString", sig(String.class));
+                        areturn();
+                    }});
+                }});
+                areturn();
+            }});
+        }};
+
+        DynamicClassLoader classLoader = new DynamicClassLoader();
+        Class<?> clazz = classLoader.define(test, JDKVersion.V1_8);
+        Object callback = clazz.getMethod("getCallback").invoke(null);
+
+        shouldImplement(callback, "java.util.function.UnaryOperator");
+
+        Method method = callback.getClass().getMethod("apply", Object.class);
+        method.setAccessible(true);
+        assertEquals(method.invoke(callback, "World"), "Hello, World!");
+    }
+
+    private void shouldImplement(Object object, String interfaceType) {
+        boolean found = false;
+        for (Class<?> i : object.getClass().getInterfaces()) {
+            if (i.getCanonicalName().equals(interfaceType)) {
+                found = true;
+                break;
+            }
+        }
+        assertTrue(object + " does not implement " + interfaceType, found);
     }
 }


### PR DESCRIPTION
Hey @qmx! I've added a simple DSL block for generating lambdas more easily, mostly because I find the multiple invokedynamic arguments required for lambdas is tough to get my head around.

In a nutshell, lambdas require the following:
* Functional interface type, method, and signature
* Optional specialization of the functional interface method signature
* The number and types of the arguments to capture off the stack
* The method to delegate the lambda to

Using this information, the relevant invokedynamic instruction is created to delegate into the implementation method.

**Caveats:**
The lambda block test (JiteClassTest#testLambda) is only run on Java 8. The test method exits if not running Java 8. I've taken steps to ensure Java 8 isn't required when using jitescript by coding all JDK 8 class names as strings. Is there a better way to manage the test given the JDK version constraint? :S

**Examples:**
* [JiteClassTest#testLambda](https://github.com/lmcgrath/jitescript/blob/5ed77c1143e05b78da751f7e08604f3782e7d059/src/test/java/me/qmx/jitescript/JiteClassTest.java#L205-L222)
* [Lambda for partial function application](https://github.com/lmcgrath/scotch-lang/blob/11597232a0fac82fe7150b163280d54ade5877f6/src/main/java/scotch/compiler/generator/BytecodeGenerator.java#L83-L95)
* [Lambda for curried function](https://github.com/lmcgrath/scotch-lang/blob/11597232a0fac82fe7150b163280d54ade5877f6/src/main/java/scotch/compiler/generator/BytecodeGenerator.java#L142-L157)